### PR TITLE
Fix non-method error

### DIFF
--- a/src/slices.types.d.ts
+++ b/src/slices.types.d.ts
@@ -71,7 +71,7 @@ export type ValidateSliceCaseReducers<TState, TCaseReducers extends SliceCaseRed
 		reducer(s: TState, action?: infer TAction): any;
 	}
 		? {
-				prepare(...a: never[]): Omit<TAction, "type">;
+				prepare: (...a: never[]) => Omit<TAction, "type">;
 		  }
 		: {};
 };


### PR DESCRIPTION
I get this error when trying to use the [prepare feature](https://redux-toolkit.js.org/api/createSlice#customizing-generated-action-creators):
```
error TS roblox-ts: Attempted to assign non-method where method was expected.

 18             prepare: () => {
                ~~~~~~~~~~~~~~~~
 19                 return {
    ~~~~~~~~~~~~~~~~~~~~~~~~
... 
 23                 };
    ~~~~~~~~~~~~~~~~~~
 24             },
```

I had to convert it to a method instead:
```ts
            prepare() {
                return {
                    payload: {
                        promptId: HttpService.GenerateGUID(),
                    },
                };
            },
```

But this compiles incorrectly:
```lua
			prepare = function(self)
				return {
					payload = {
						promptId = HttpService:GenerateGUID(),
					},
				}
			end,
```
The self shouldn't be there.

This PR fixes that by changing some types to use a property instead of a method